### PR TITLE
Compute parametrics coordinates of the periodic cad

### DIFF
--- a/src/EGADS/include/egads.h
+++ b/src/EGADS/include/egads.h
@@ -285,9 +285,7 @@ __ProtoExt__ int  EG_loadTess( ego body, const char *name, ego *tess );
 
 __ProtoExt__ int  EG_tessMassProps( const ego tess, double *props );
 
-__ProtoExt__ double EG_periodic_paramt_interpolation( double t0_src, double t1_src, double t0_tgt, double t1_tgt, double t_src);
-
-__ProtoExt__ void EG_periodic_paramuv_interpolation( double uv0_src[2], double uv1_src[2], double uv0_tgt[2], double uv1_tgt[2], double uv_src[2], double uv_tgt[2]);
+__ProtoExt__ int EG_periodic_paramtuv_interpolation( int dim, const double *tuv0_src, const double *tuv1_src, const double *tuv0_tgt, const double *tuv1_tgt, const double *tuv_src, double *tuv_tgt);
 
 /* top down build functions */
 

--- a/src/EGADS/include/egads.h
+++ b/src/EGADS/include/egads.h
@@ -285,6 +285,10 @@ __ProtoExt__ int  EG_loadTess( ego body, const char *name, ego *tess );
 
 __ProtoExt__ int  EG_tessMassProps( const ego tess, double *props );
 
+__ProtoExt__ double EG_periodic_paramt_interpolation( double t0_src, double t1_src, double t0_tgt, double t1_tgt, double t_src);
+
+__ProtoExt__ void EG_periodic_paramuv_interpolation( double uv0_src[2], double uv1_src[2], double uv0_tgt[2], double uv1_tgt[2], double uv_src[2], double uv_tgt[2]);
+
 /* top down build functions */
 
 __ProtoExt__ int  EG_fuseSheets( const ego src, const ego tool, ego *sheet );

--- a/src/EGADS/src/egads.def
+++ b/src/EGADS/src/egads.def
@@ -132,8 +132,7 @@ EG_makeTessGeom
 EG_getTessGeom
 EG_makeTessBody
 EG_makePeriodicTessBody
-EG_periodic_paramt_interpolation
-EG_periodic_paramuv_interpolation
+EG_periodic_paramtuv_interpolation
 EG_remakeTess
 EG_finishTess
 EG_mapTessBody

--- a/src/EGADS/src/egads.def
+++ b/src/EGADS/src/egads.def
@@ -132,6 +132,8 @@ EG_makeTessGeom
 EG_getTessGeom
 EG_makeTessBody
 EG_makePeriodicTessBody
+EG_periodic_paramt_interpolation
+EG_periodic_paramuv_interpolation
 EG_remakeTess
 EG_finishTess
 EG_mapTessBody

--- a/src/EGADS/src/egadsTess.c
+++ b/src/EGADS/src/egadsTess.c
@@ -1025,6 +1025,18 @@ _periodize_surface_tesselation
   EG_free(faces);
 }
 
+__HOST_AND_DEVICE__ double
+EG_periodic_paramt_interpolation(double t0_src, double t1_src, double t0_tgt, double t1_tgt, double t_src)
+{
+  return (_periodic_paramt_interpolation(t0_src, t1_src, t0_tgt, t1_tgt, t_src));
+}
+
+__HOST_AND_DEVICE__ void
+EG_periodic_paramuv_interpolation(double uv0_src[2], double uv1_src[2], double uv0_tgt[2], double uv1_tgt[2], double uv_src[2], double uv_tgt[2])
+{
+  uv_tgt[0] = _periodic_paramt_interpolation(uv0_src[0], uv1_src[0], uv0_tgt[0], uv1_tgt[0], uv_src[0]);
+  uv_tgt[1] = _periodic_paramt_interpolation(uv0_src[1], uv1_src[1], uv0_tgt[1], uv1_tgt[1], uv_src[1]);
+}
 
 __HOST_AND_DEVICE__ static int
 EG_attrRet3R(const egObject *obj, const char *name, double *vals)

--- a/src/EGADS/src/egadsTess.c
+++ b/src/EGADS/src/egadsTess.c
@@ -1025,17 +1025,17 @@ _periodize_surface_tesselation
   EG_free(faces);
 }
 
-__HOST_AND_DEVICE__ double
-EG_periodic_paramt_interpolation(double t0_src, double t1_src, double t0_tgt, double t1_tgt, double t_src)
+__HOST_AND_DEVICE__ int
+EG_periodic_paramtuv_interpolation(int dim, const double *tuv0_src, const double *tuv1_src, const double *tuv0_tgt, const double *tuv1_tgt, const double *tuv_src, double *tuv_tgt)
 {
-  return (_periodic_paramt_interpolation(t0_src, t1_src, t0_tgt, t1_tgt, t_src));
-}
+  if (dim > 2)
+    return EGADS_GEOMERR;
 
-__HOST_AND_DEVICE__ void
-EG_periodic_paramuv_interpolation(double uv0_src[2], double uv1_src[2], double uv0_tgt[2], double uv1_tgt[2], double uv_src[2], double uv_tgt[2])
-{
-  uv_tgt[0] = _periodic_paramt_interpolation(uv0_src[0], uv1_src[0], uv0_tgt[0], uv1_tgt[0], uv_src[0]);
-  uv_tgt[1] = _periodic_paramt_interpolation(uv0_src[1], uv1_src[1], uv0_tgt[1], uv1_tgt[1], uv_src[1]);
+  for (int i=0; i<dim; i++)
+  {
+    tuv_tgt[i] = _periodic_paramt_interpolation(tuv0_src[i], tuv1_src[i], tuv0_tgt[i], tuv1_tgt[i], tuv_src[i]);
+  }
+  return EGADS_SUCCESS;
 }
 
 __HOST_AND_DEVICE__ static int


### PR DESCRIPTION
This development aims to compute parametric coordinates (t for edges ant (u,v) for faces) of the periodic cad knowing : 
- topologic information of the source cad and the periodic cad (`EG_getTopology`)
- parametric coordinates of the source cad (`ADTH_geom_group_parametric_coords_get`)

The functions are located in `egadsTess.c` because `_periodic_paramt_interpolation` is already located here, maybe move them to a more appropriate file.